### PR TITLE
chore(golang): Updated GoLang requirements to 1.24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Build binaries
         id: build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
+          cache: true
       - name: Install dependencies
-        run: go get -v ./...
+        run: go mod download
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This exporter connects to MikroTik routers using the native API (via the `go-rou
 
 ## Requirements
 
-- Go (version 1.18+ recommended)
+- Go 1.24+ required
 - MikroTik RouterOS v6.48 or later (tested with both v6.x and v7.x API features)
 - A dedicated read-only user on the MikroTik router for the exporter
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/taihen/ros-exporter
 
-go 1.24.2
+go 1.24
 
 require (
 	github.com/go-routeros/routeros/v3 v3.0.1


### PR DESCRIPTION
As per PR title, updating requirements to Go 1.24+.
